### PR TITLE
Malformed Authentication headers cause requests to never complete

### DIFF
--- a/lib/auth_header.js
+++ b/lib/auth_header.js
@@ -1,13 +1,13 @@
 
 var re = /(\S+)\s+(\S+)/
 
-function parseAuthHeader(hdrValue) { 
-    if (!typeof hdrValue === 'string') {
+function parseAuthHeader(hdrValue) {
+    if (typeof hdrValue !== 'string') {
         return null;
     }
 
     matches = hdrValue.match(re);
-    return { scheme: matches[1], value: matches[2] }
+    return matches && { scheme: matches[1], value: matches[2] }
 }
 
 module.exports = {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -75,6 +75,9 @@ JwtStrategy.prototype.authenticate = function(req, options) {
     // Try the header first
     if( req.headers[AUTH_HEADER]) {
         var auth_params = auth_hdr.parse(req.headers[AUTH_HEADER]);
+        if (!auth_params) {
+            return self.fail(new Error("Invalid authorization header"));
+        }
         if (self._authScheme === auth_params.scheme) {
             token = auth_params.value;
         }

--- a/test/auth_header-test.js
+++ b/test/auth_header-test.js
@@ -15,4 +15,10 @@ describe('Parsing Auth Header field-value', function() {
     });
 
 
+    it('Should handle malformed authentication headers with no scheme', function() {
+        var res = auth_hdr.parse("malformed");
+        expect(res).to.not.be.ok;
+    });
+
+
 });

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -119,5 +119,37 @@ describe('Strategy', function() {
 
     });
 
+
+    describe('handling an invalid authentication header', function() {
+        var strategy, info; 
+        var verify_spy = sinon.spy();
+
+        before(function(done) {
+
+            strategy = new Strategy({secretOrKey: 'secret'}, verify_spy);
+
+            chai.passport.use(strategy)
+                .fail(function(i) {
+                    info = i;
+                    done();
+                })
+                .req(function(req) {
+                    req.headers['authorization'] = "malformed";
+                })
+                .authenticate();
+        });
+
+
+        it('should not call verify', function() {
+            sinon.assert.notCalled(verify_spy);
+        });
+
+
+        it('should fail with error message.', function() {
+            expect(info).to.be.an.object;
+            expect(info.message).to.equal('Invalid authorization header');
+        });
+
+    });
+
 });
- 


### PR DESCRIPTION
For example:

```
curl -H 'Authorization: {removed}' http://localhost/mysecuredapi
```

this is malformed and doesn't have a scheme, and should 401 or 400, but it should not hang