### PR TITLE
Add ability to read JWT from query parameters.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,11 +1,14 @@
 var passport = require('passport-strategy')
     , auth_hdr = require('./auth_header')
-    , util = require('util');
+    , util = require('util')
+    , url = require('url');
 
 // Note: express http converts all headers
 // to lower case.
 var AUTH_HEADER = "authorization"
     , DEFAULT_AUTH_SCHEME = "JWT"
+    , DEFAULT_TOKEN_BODY_FIELD = 'auth_token'
+    , DEFAULT_TOKEN_QUERY_PARAM_NAME = 'auth_token'
 
 /**
  * Strategy constructor
@@ -15,6 +18,7 @@ var AUTH_HEADER = "authorization"
  *          issuer: If defined issuer will be verified against this value
  *          audience: If defined audience will be verified against this value
  *          tokenBodyField: Field in request body containing token. Default is auth_token.
+ *          tokenQueryParameterName: Query parameter name containing the token. Default is auth_token.
  *          authScheme: Expected scheme when JWT can be found in HTTP Authorize header. Default is JWT.
  *          passReqToCallback: If true the, the verify callback will be called with args (request, jwt_payload, done_callback).
  * @param verify - Verify callback with args (jwt_payload, done_callback) if passReqToCallback is false,
@@ -37,8 +41,9 @@ function JwtStrategy(options, verify) {
 
     this._passReqToCallback = options.passReqToCallback;
     this._authScheme = options.authScheme || DEFAULT_AUTH_SCHEME;
-    this._tokenBodyField = options.tokenBodyField;
-    this._verifOpts = {} 
+    this._tokenBodyField = options.tokenBodyField || DEFAULT_TOKEN_BODY_FIELD;
+    this._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
+    this._verifOpts = {};
 
     if (options.issuer) {
         this._verifOpts.issuer = options.issuer;
@@ -85,7 +90,11 @@ JwtStrategy.prototype.authenticate = function(req, options) {
 
     // If not in the header try the body
     if (!token && req.body) {
-        token = req.body.auth_token;
+        token = req.body[self._tokenBodyField];
+    }
+
+    if (!token) {
+        token = url.parse(req.url, true).query[self._tokenQueryParameterName];
     }
 
     if (!token) {

--- a/test/strategy-requests-test.js
+++ b/test/strategy-requests-test.js
@@ -45,7 +45,7 @@ describe('Strategy', function() {
     });
 
 
-    describe('handling request with JWT in body', function() {
+    describe('handling request with JWT in default body field', function() {
          var strategy;
 
         before(function(done) {
@@ -72,10 +72,90 @@ describe('Strategy', function() {
             sinon.assert.calledOnce(mockVerifier);
             expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
         });
+    });
+
+    describe('handling request with JWT in custom body field', function() {
+         var strategy;
+
+        before(function(done) {
+            strategy = new Strategy({secretOrKey: 'secret', tokenBodyField: 'jwtToken'}, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+            
+            mockVerifier.reset();
+           
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.body = {}
+                    req.body.jwtToken = test_data.valid_jwt.token;
+                })
+                .authenticate();
+        });
+
+
+        it("verifies the right jwt", function() {
+            sinon.assert.calledOnce(mockVerifier);
+            expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
+        });
 
 
     });
 
+    describe('handling request with JWT in default query parameter', function() {
+        var strategy;
+
+        before(function(done) {
+            strategy = new Strategy({secretOrKey: 'secret'}, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+            mockVerifier.reset();
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.url += '?auth_token=' + test_data.valid_jwt.token;
+                })
+                .authenticate();
+        });
+
+
+        it("verifies the right jwt", function() {
+            sinon.assert.calledOnce(mockVerifier);
+            expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
+        });
+    });
+
+    describe('handling request with JWT in custom query parameter', function() {
+        var strategy;
+
+        before(function(done) {
+            strategy = new Strategy({secretOrKey: 'secret', tokenQueryParameterName: 'jwt_token'}, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+            mockVerifier.reset();
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.url += '?jwt_token=' + test_data.valid_jwt.token;
+                })
+                .authenticate();
+        });
+
+
+        it("verifies the right jwt", function() {
+            sinon.assert.calledOnce(mockVerifier);
+            expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
+        });
+    });
 
     describe('handling request with NO JWT', function() {
 


### PR DESCRIPTION
* Add default query parameter name (auth_token).
* Fixed body token field to be read according to options.
* Add tests.