### PR TITLE
added ignoreExpiration option so that users can handle the expiration date validation 

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,6 +45,9 @@ function JwtStrategy(options, verify) {
     this._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
     this._verifOpts = {};
 
+    if (options.ignoreExpiration) {
+        this._verifOpts.ignoreExpiration = options.ignoreExpiration;
+    }
     if (options.issuer) {
         this._verifOpts.issuer = options.issuer;
     }


### PR DESCRIPTION
currently the json web token framework being used for validation automatically validates the expiration timestamp against the current date. I would like to be able to handle this configuration in my JWT strategy in my passport configuration. Since the jwt framework automatically validates it and fails it, my code block never executes within passport, it just throws a 401. 