### PR TITLE
Read JWT from custom header

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ extracted from the request or verified.
   value.
 * `audience`: If defined, the token audience (aud) will be verified against
   this value.
+* `tokenHeaderField`: Header in request containing the jwt.
+  Default is to use JWT Authorization header.
 * `tokenBodyField`: Field in a request body to search for the jwt.
   Default is auth_token.
 * `tokenQueryParameterName`: Query parameter name containing the token.
@@ -90,6 +92,8 @@ body will be checked for a field matching either `options.tokenBodyField` or
 Finally, the URL query parameters will be checked for a field matching either
 `options.tokenQueryParameterName` or `auth_token` if the option was not
 sepcified.
+
+If you are using a custom header, you can specify it with `tokenHeaderField`.
 
 ## Tests
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -17,6 +17,7 @@ var AUTH_HEADER = "authorization"
  *          secretOrKey - (REQUIRED) String or buffer containing the secret or PEM-encoded public key
  *          issuer: If defined issuer will be verified against this value
  *          audience: If defined audience will be verified against this value
+ *          tokenHeaderField: Header in request containing token.
  *          tokenBodyField: Field in request body containing token. Default is auth_token.
  *          tokenQueryParameterName: Query parameter name containing the token. Default is auth_token.
  *          authScheme: Expected scheme when JWT can be found in HTTP Authorize header. Default is JWT.
@@ -41,6 +42,7 @@ function JwtStrategy(options, verify) {
 
     this._passReqToCallback = options.passReqToCallback;
     this._authScheme = options.authScheme || DEFAULT_AUTH_SCHEME;
+    this._tokenHeaderField = options.tokenHeaderField;
     this._tokenBodyField = options.tokenBodyField || DEFAULT_TOKEN_BODY_FIELD;
     this._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
     this._verifOpts = {};
@@ -86,6 +88,8 @@ JwtStrategy.prototype.authenticate = function(req, options) {
         if (self._authScheme === auth_params.scheme) {
             token = auth_params.value;
         }
+    } else if (!!self._tokenHeaderField && typeof req.headers[self._tokenHeaderField] === 'string') {
+        token = req.headers[self._tokenHeaderField];
     }
 
     // If not in the header try the body

--- a/test/strategy-requests-test.js
+++ b/test/strategy-requests-test.js
@@ -45,6 +45,35 @@ describe('Strategy', function() {
     });
 
 
+    describe('handling request with JWT in custom header', function() {
+        var strategy;
+
+        before(function(done) {
+            strategy = new Strategy({secretOrKey: 'secret', tokenHeaderField: 'x-jwt-auth'}, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+            
+            mockVerifier.reset();           
+
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.headers['x-jwt-auth'] = test_data.valid_jwt.token;
+                })
+                .authenticate();
+        });
+
+        it("verifies the right jwt", function() {
+            sinon.assert.calledOnce(mockVerifier);
+            expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
+        });
+
+    });
+
+
     describe('handling request with JWT in default body field', function() {
          var strategy;
 


### PR DESCRIPTION
We use JWT as if it were an API token. It would be nice to configure passport to read from a custom HTTP header not using the JWT auth scheme.