### PR TITLE
Add option for ignoreException

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ extracted from the request or verified.
   value.
 * `audience`: If defined, the token audience (aud) will be verified against
   this value.
-* `algorithms`: List of strings with the names of the allowed algorithms. For instance, ["HS256", "HS384"]
+* `algorithms`: List of strings with the names of the allowed algorithms. For instance, ["HS256", "HS384"].
+* `ignoreExpiration`: if true do not validate the expiration of the token.
+
 * `tokenBodyField`: Field in a request body to search for the jwt.
   Default is auth_token.
 * `tokenQueryParameterName`: Query parameter name containing the token.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,7 +20,8 @@ var AUTH_HEADER = "authorization"
  *          tokenBodyField: Field in request body containing token. Default is auth_token.
  *          tokenQueryParameterName: Query parameter name containing the token. Default is auth_token.
  *          authScheme: Expected scheme when JWT can be found in HTTP Authorize header. Default is JWT.
- *          algorithms: List of strings with the names of the allowed algorithms. For instance, ["HS256", "HS384"]
+ *          algorithms: List of strings with the names of the allowed algorithms. For instance, ["HS256", "HS384"].
+ *          ignoreExpiration: if true do not validate the expiration of the token.
  *          passReqToCallback: If true the, the verify callback will be called with args (request, jwt_payload, done_callback).
  * @param verify - Verify callback with args (jwt_payload, done_callback) if passReqToCallback is false,
  *                 (request, jwt_payload, done_callback) if true.
@@ -55,7 +56,11 @@ function JwtStrategy(options, verify) {
     }
 
     if (options.algorithms) {
-      this._verifOpts.algorithms = options.algorithms;
+        this._verifOpts.algorithms = options.algorithms;
+    }
+
+    if (options.ignoreExpiration != null) {
+        this._verifOpts.ignoreExpiration = options.ignoreExpiration;
     }
 
 };

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -16,6 +16,7 @@ describe('Strategy', function() {
             options.audience = "TestAudience";
             options.secretOrKey = 'secret';
             options.algorithms = ["HS256", "HS384"];
+            options.ignoreExpiration = false;
             strategy = new Strategy(options, verifyStub);
 
             Strategy.JwtVerifier = sinon.stub();
@@ -53,6 +54,10 @@ describe('Strategy', function() {
             expect(Strategy.JwtVerifier.args[0][2].algorithms).to.eql(["HS256", "HS384"]);
         });
 
+        it('should call with the right ignoreExpiration option', function() {
+            expect(Strategy.JwtVerifier.args[0][2]).to.be.an.object;
+            expect(Strategy.JwtVerifier.args[0][2].ignoreExpiration).to.be.false;
+        });
 
     });
 


### PR DESCRIPTION
From the jsonwebtoken options:
ignoreExpiration: if true do not validate the expiration of the token.

fixes #13