### PR TITLE
Add passTokenToRequest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ extracted from the request or verified.
   the HTTP Authorization header. Defaults to JWT
 * `passReqToCallback`: If true the request will be passed to the verify
   callback. i.e. verify(request, jwt_payload, done_callback).
+* `passTokenToCallback`: If true the token will be passed to the verify
+  callback. i.e. verify(token, jwt_payload, done_callback). If both this and the
+  previous option are set, callback will be called with both the request and the
+  token. i.e. verify(request, token, jwt_payload, done_callback).
 
 `verify` is a function with args `verify(jwt_payload, done)`
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -23,6 +23,7 @@ var AUTH_HEADER = "authorization"
  *          algorithms: List of strings with the names of the allowed algorithms. For instance, ["HS256", "HS384"].
  *          ignoreExpiration: if true do not validate the expiration of the token.
  *          passReqToCallback: If true the, the verify callback will be called with args (request, jwt_payload, done_callback).
+ *          passTokenToCallback: If true the, the verify callback will be called with args (request, jwt_token, jwt_payload, done_callback).
  * @param verify - Verify callback with args (jwt_payload, done_callback) if passReqToCallback is false,
  *                 (request, jwt_payload, done_callback) if true.
  */
@@ -42,6 +43,7 @@ function JwtStrategy(options, verify) {
     }
 
     this._passReqToCallback = options.passReqToCallback;
+    this._passTokenToCallback = options.passTokenToCallback;
     this._authScheme = options.authScheme || DEFAULT_AUTH_SCHEME;
     this._tokenBodyField = options.tokenBodyField || DEFAULT_TOKEN_BODY_FIELD;
     this._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
@@ -131,8 +133,12 @@ JwtStrategy.prototype.authenticate = function(req, options) {
             };
 
             try {
-                if (self._passReqToCallback) {
+                if (self._passReqToCallback && self._passTokenToCallback) {
+                    self._verify(req, token, payload, verified);
+                } else if (self._passReqToCallback) {
                     self._verify(req, payload, verified);
+                } else if (self._passTokenToCallback) {
+                    self._verify(token, payload, verified);
                 } else {
                     self._verify(payload, verified);
                 }

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -167,4 +167,66 @@ describe('Strategy', function() {
 
     });
 
+    describe('handling a request with a valid jwt and option passTokenToCallback is true', function() {
+
+        var strategy, expected_token, token_arg;
+
+        before(function(done) {
+            opts = { passTokenToCallback: true };
+            opts.secretOrKey = 'secret';
+            strategy = new Strategy(opts, function(token, jwt_payload, next) {
+                // Capture the value passed in as the token argument
+                token_arg = token;
+                return next(null, {user_id: 1234567890}, {foo:'bar'});
+            });
+
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    expected_token = test_data.valid_jwt.token;
+                })
+                .authenticate();
+        });
+
+        it('will call verify with token as the first argument', function() {
+            expect(expected_token).to.equal(token_arg);
+        });
+
+    });
+
+    describe('handling a request with a valid jwt and options passReqToCallback and passTokenToCallback both true', function() {
+
+        var strategy, expected_request, request_arg, expected_token, token_arg;
+
+        before(function(done) {
+            opts = { passReqToCallback: true, passTokenToCallback: true };
+            opts.secretOrKey = 'secret';
+            strategy = new Strategy(opts, function(request, token, jwt_payload, next) {
+                // Capture the value passed in as the token argument
+                request_arg = request;
+                token_arg = token;
+                return next(null, {user_id: 1234567890}, {foo:'bar'});
+            });
+
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    expected_token = test_data.valid_jwt.token;
+                    expected_request = req;
+                })
+                .authenticate();
+        });
+
+        it('will call verify with request as the first argument and token as the second argument', function() {
+            expect(expected_request).to.equal(request_arg);
+            expect(expected_token).to.equal(token_arg);
+        });
+
+    });
 });


### PR DESCRIPTION
I am working on an application where we are passing the JWT token to the client application so it can be used in cross-domain requests.  This options makes it easier to get the token as detected by the strategy, instead of having to extract it from the various places where it can be found (cookie, http header, query string).
