### PR TITLE
allow secretOrKey to be a function rather than a string or buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications, you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or null / undefied if a secret could not be determined.)
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or `null` / `undefined` if a secret could not be determined.
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or `null` / `undefined` if a secret could not be determined.
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback is of the form `done(err, secret)` where `err` will be `null` if there is no error.
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The jwt authentication strategy is constructed as follows:
 `options` is an object literal containing options to control how the token is
 extracted from the request or verified.
 
-* `secretOrKey` is a REQUIRED string or buffer containing the secret
+* `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature.
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications, you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or null / undefied if a secret could not be determined.)
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,5 +1,15 @@
 var jwt = require('jsonwebtoken');
 
-module.exports  = function(token, secretOrKey, options, callback) { 
-    return jwt.verify(token, secretOrKey, options, callback);
+module.exports  = function(token, secretOrKey, options, callback) {
+  if (typeof secretOrKey === 'function') {
+      secretOrKey(token, function(secret) {
+        if (!secret) {
+          callback(new Error('Could not determine secret'), null);
+        } else {
+          return jwt.verify(token, secret, options, callback);
+        }
+      })
+  } else {
+      return jwt.verify(token, secretOrKey, options, callback);
+  }
 };

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -2,8 +2,10 @@ var jwt = require('jsonwebtoken');
 
 module.exports  = function(token, secretOrKey, options, callback) {
   if (typeof secretOrKey === 'function') {
-      secretOrKey(token, function(secret) {
-        if (!secret) {
+      secretOrKey(token, function(err, secret) {
+        if (err) {
+          callback(err, null);
+        } else if (!secret) {
           callback(new Error('Could not determine secret'), null);
         } else {
           return jwt.verify(token, secret, options, callback);

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -167,4 +167,72 @@ describe('Strategy', function() {
 
     });
 
+    describe('Handling a request with a valid JWT, secretOrKey is a function, and succesful verification', function() {
+        describe('secretOrKey function returns a secret', function() {
+            var strategy, user, info; 
+            var secretFunction = function(token, done) {
+                done('secret');
+            };
+
+            before(function(done) {
+                strategy = new Strategy({secretOrKey: secretFunction}, function(jwt_paylod, next) {
+                    return next(null, {user_id: 1234567890}, {foo:'bar'});
+                });
+
+                chai.passport.use(strategy)
+                    .success(function(u, i) {
+                        user = u;
+                        info = i;
+                        done();
+                    })
+                    .req(function(req) {
+                        req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    })
+                    .authenticate();
+            });
+
+
+            it('should provide a user', function() {
+                expect(user).to.be.an.object;
+                expect(user.user_id).to.equal(1234567890);
+            });
+
+
+            it('should forward info', function() {
+                expect(info).to.be.an.object;
+                expect(info.foo).to.equal('bar');
+            });
+        });
+
+        describe('secretOrKey function doesn\'t return a secret', function() {
+            var strategy, err; 
+            var secretFunction = function(token, done) {
+                done();
+            };
+
+            before(function(done) {
+                strategy = new Strategy({secretOrKey: secretFunction}, function(jwt_paylod, next) {
+                    return next(new Error('ERROR'), false, {message: 'Could not determine secret'});
+                });
+
+                chai.passport.use(strategy)
+                    .error(function(e) {
+                        err = e;
+                        done();
+                    })
+                    .req(function(req) {
+                        req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    })
+                    .authenticate();
+            });
+
+
+            it('should error', function() {
+                expect(err).to.be.an.instanceof(Error);
+                expect(err.message).to.equal('ERROR');
+            });
+        });
+
+    });
+
 });

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -171,7 +171,7 @@ describe('Strategy', function() {
         describe('secretOrKey function returns a secret', function() {
             var strategy, user, info; 
             var secretFunction = function(token, done) {
-                done('secret');
+                done(null, 'secret');
             };
 
             before(function(done) {
@@ -207,7 +207,7 @@ describe('Strategy', function() {
         describe('secretOrKey function doesn\'t return a secret', function() {
             var strategy, err; 
             var secretFunction = function(token, done) {
-                done();
+                done(new Error('oops'), null);
             };
 
             before(function(done) {


### PR DESCRIPTION
thus enabling secret lookups in multi-tennanted applications.

Resolves issue #37 
