### PR TITLE
#37 evaluate options for each authenticate call

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ passport.use(new JwtStrategy(opts, function(jwt_payload, done) {
 }));
 ```
 
+### Make the strategy's options dynamic
+
+The options given to the JwtStrategy constructor can be a function, which will be called each time that Passport will use this strategy to authenticate a request.
+
+This can be useful when your JWT options can change (i.e. read from a file or a database), or in case of multi-tenanted applications.
+
+    function optionsResolver(optionsCallback) {
+      myOptionsProvider(function(options) {
+        if (!options) {
+          optionsCallback(new Error('No options found'));
+        } else {
+          optionsCallback(null, options);
+        }
+      });
+    }
+
+    passport.use(new JwtStrategy(optionsResolver, verify))
+
+`optionsResolver` is a function taking a callback (in the format function(err, options))
+
 ### Authenticate requests
 
 Use `passport.authenticate()` specifying `'jwt'` as the strategy.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -13,7 +13,8 @@ var AUTH_HEADER = "authorization"
 /**
  * Strategy constructor
  *
- * @param options
+ * @param options - Object containing fields:
+ *               or Function taking a callback (in the format function(err, dynamicOptions)) as argument, the `dynamicOptions` should be an object containing fields:
  *          secretOrKey - (REQUIRED) String or buffer containing the secret or PEM-encoded public key
  *          issuer: If defined issuer will be verified against this value
  *          audience: If defined audience will be verified against this value
@@ -31,42 +32,71 @@ function JwtStrategy(options, verify) {
     passport.Strategy.call(this);
     this.name = 'jwt';
 
-    this._secretOrKey = options.secretOrKey;
-    if (!this._secretOrKey) {
-        throw new TypeError('JwtStrategy requires a secret or key');
-    }
-
     this._verify = verify;
     if (!this._verify) {
         throw new TypeError('JwtStrategy requires a verify callback');
     }
 
-    this._passReqToCallback = options.passReqToCallback;
-    this._authScheme = options.authScheme || DEFAULT_AUTH_SCHEME;
-    this._tokenBodyField = options.tokenBodyField || DEFAULT_TOKEN_BODY_FIELD;
-    this._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
-    this._verifOpts = {};
+    if (typeof options !== "function") {
+      var staticOptions = _buildOptions(options);
+      this._getOptions = function(callback) {
+        callback(null, staticOptions);
+      };
+    } else {
+      this._getOptions = function(callback) {
+        options(function(err, dynamicOptions) {
+          if (err) {
+            callback(err);
+          } else if (!dynamicOptions) {
+            callback(new Error('No jwt options'));
+          } else {
+            callback(null, _buildOptions(dynamicOptions));
+          }
+        });
+      };
+    }
+}
+util.inherits(JwtStrategy, passport.Strategy);
+
+/**
+ * @param options - As detailed in the JwtStrategy constructor, some fields are required, others have a default value
+ *
+ * @return An object built from the given options, in the format expected by the `authenticate` method.
+ *
+ * @see JwtStrategy options
+ */
+function _buildOptions(options) {
+    var result = {};
+
+    result._secretOrKey = options.secretOrKey;
+    if (!result._secretOrKey) {
+        throw new TypeError('JwtStrategy requires a secret or key');
+    }
+
+    result._passReqToCallback = options.passReqToCallback;
+    result._authScheme = options.authScheme || DEFAULT_AUTH_SCHEME;
+    result._tokenBodyField = options.tokenBodyField || DEFAULT_TOKEN_BODY_FIELD;
+    result._tokenQueryParameterName = options.tokenQueryParameterName || DEFAULT_TOKEN_QUERY_PARAM_NAME;
+    result._verifOpts = {};
 
     if (options.issuer) {
-        this._verifOpts.issuer = options.issuer;
+        result._verifOpts.issuer = options.issuer;
     }
 
     if (options.audience) {
-        this._verifOpts.audience = options.audience;
+        result._verifOpts.audience = options.audience;
     }
 
     if (options.algorithms) {
-        this._verifOpts.algorithms = options.algorithms;
+        result._verifOpts.algorithms = options.algorithms;
     }
 
     if (options.ignoreExpiration != null) {
-        this._verifOpts.ignoreExpiration = options.ignoreExpiration;
+        result._verifOpts.ignoreExpiration = options.ignoreExpiration;
     }
 
-};
-util.inherits(JwtStrategy, passport.Strategy);
-
-
+    return result;
+}
 
 /**
  * Allow for injection of JWT Verifier.
@@ -83,63 +113,70 @@ JwtStrategy.JwtVerifier = require('./verify_jwt');
 /**
  * Authenticate request based on JWT obtained from header or post body
  */
-JwtStrategy.prototype.authenticate = function(req, options) {
+JwtStrategy.prototype.authenticate = function(req) {
     var self = this;
     var token = null;
-    // Extract the jwt from the request
-    // Try the header first
-    if( req.headers[AUTH_HEADER]) {
-        var auth_params = auth_hdr.parse(req.headers[AUTH_HEADER]);
-        if (!auth_params) {
-            return self.fail(new Error("Invalid authorization header"));
-        }
-        if (self._authScheme === auth_params.scheme) {
-            token = auth_params.value;
-        }
-    }
+    this._getOptions(function(err, jwtOptions) {
 
-    // If not in the header try the body
-    if (!token && req.body) {
-        token = req.body[self._tokenBodyField];
-    }
+      if (err) {
+          return self.fail(err);
+      }
 
-    if (!token) {
-        var parsed_url = url.parse(req.url, true);
-        if (parsed_url.query && parsed_url.query.hasOwnProperty(self._tokenQueryParameterName)) {
-            token = parsed_url.query[self._tokenQueryParameterName];
-        }
-    }
+      // Extract the jwt from the request
+      // Try the header first
+      if( req.headers[AUTH_HEADER]) {
+          var auth_params = auth_hdr.parse(req.headers[AUTH_HEADER]);
+          if (!auth_params) {
+              return self.fail(new Error("Invalid authorization header"));
+          }
+          if (jwtOptions._authScheme === auth_params.scheme) {
+              token = auth_params.value;
+          }
+      }
 
-    if (!token) {
-        return self.fail(new Error("No auth token"));
-    }
+      // If not in the header try the body
+      if (!token && req.body) {
+          token = req.body[jwtOptions._tokenBodyField];
+      }
 
-    // Verify the JWT
-    JwtStrategy.JwtVerifier(token, this._secretOrKey, this._verifOpts, function(jwt_err, payload) {
-        if (jwt_err) {
-            return self.fail(jwt_err);
-        } else {
-            // Pass the parsed token to the user
-            var verified = function(err, user, info) {
-                if(err) {
-                    return self.error(err);
-                } else if (!user) {
-                    return self.fail(info);
-                } else {
-                    return self.success(user, info);
-                }
-            };
+      if (!token) {
+          var parsed_url = url.parse(req.url, true);
+          if (parsed_url.query && parsed_url.query.hasOwnProperty(jwtOptions._tokenQueryParameterName)) {
+              token = parsed_url.query[jwtOptions._tokenQueryParameterName];
+          }
+      }
 
-            try {
-                if (self._passReqToCallback) {
-                    self._verify(req, payload, verified);
-                } else {
-                    self._verify(payload, verified);
-                }
-            } catch(ex) {
-                self.error(ex);
-            }
-        }
+      if (!token) {
+          return self.fail(new Error("No auth token"));
+      }
+
+      // Verify the JWT
+      JwtStrategy.JwtVerifier(token, jwtOptions._secretOrKey, jwtOptions._verifOpts, function(jwt_err, payload) {
+          if (jwt_err) {
+              return self.fail(jwt_err);
+          } else {
+              // Pass the parsed token to the user
+              var verified = function(err, user, info) {
+                  if(err) {
+                      return self.error(err);
+                  } else if (!user) {
+                      return self.fail(info);
+                  } else {
+                      return self.success(user, info);
+                  }
+              };
+
+              try {
+                  if (jwtOptions._passReqToCallback) {
+                      self._verify(req, payload, verified);
+                  } else {
+                      self._verify(payload, verified);
+                  }
+              } catch(ex) {
+                  self.error(ex);
+              }
+          }
+      });
     });
 };
 

--- a/test/strategy-init-test.js
+++ b/test/strategy-init-test.js
@@ -1,9 +1,11 @@
 var Strategy = require('../lib/strategy');
 
 describe('Strategy', function() {
-    var strategy = new Strategy({secretOrKey: 'secret'}, function() {});
+
+  describe('with options as an object', function() {
 
     it('should be named jwt', function() {
+        var strategy = new Strategy({secretOrKey: 'secret'}, function() {});
         expect(strategy.name).to.equal('jwt');
     });
 
@@ -20,4 +22,84 @@ describe('Strategy', function() {
             var s = new Strategy({secretOrKey: null}, function() {});
         }).to.throw(TypeError, 'JwtStrategy requires a secret or key');
     });
+
+
+    it('should map all options in _getOptions result', function(done) {
+        new Strategy({
+          secretOrKey: 'expected secret',
+          issuer: 'expected issuer',
+          audience: 'expected audience',
+          tokenBodyField: 'expected tokenBodyField',
+          tokenQueryParameterName: 'expected tokenQueryParameterName',
+          authScheme: 'expected authScheme',
+          algorithms: ['expected algorithms'],
+          ignoreExpiration: false,
+          passReqToCallback: false
+        }, function() {})._getOptions(function(err, options) {
+          expect(options).to.deep.equal({
+            _secretOrKey: 'expected secret',
+            _tokenBodyField: 'expected tokenBodyField',
+            _tokenQueryParameterName: 'expected tokenQueryParameterName',
+            _authScheme: 'expected authScheme',
+            _passReqToCallback: false,
+            _verifOpts : {
+              algorithms: ['expected algorithms'],
+              issuer: 'expected issuer',
+              audience: 'expected audience',
+              ignoreExpiration: false
+            }
+          });
+          done();
+        });
+    });
+  });
+
+  describe('with options as a function', function() {
+
+    it('should throw if _getOptions is called and given options has no secretOrKey', function() {
+        var verifier = function() {},
+            optionsFinder = function(optionsFoundCallback) {
+              optionsFoundCallback(null, {secretOrKey: null});
+            },
+            strategy = new Strategy(optionsFinder, verifier);
+
+        expect(function() {
+            strategy._getOptions();
+        }).to.throw(TypeError, 'JwtStrategy requires a secret or key');
+    });
+
+
+    it('should map all options in _getJwtOptions result', function(done) {
+      new Strategy(function(optionsFoundCallback) {
+        optionsFoundCallback(null, {
+          secretOrKey: 'expected secret',
+          issuer: 'expected issuer',
+          audience: 'expected audience',
+          tokenBodyField: 'expected tokenBodyField',
+          tokenQueryParameterName: 'expected tokenQueryParameterName',
+          authScheme: 'expected authScheme',
+          algorithms: ['expected algorithms'],
+          ignoreExpiration: false,
+          passReqToCallback: false
+        });
+      }, function() {})._getOptions(function(err, options) {
+          expect(options).to.deep.equal({
+            _secretOrKey: 'expected secret',
+            _tokenBodyField: 'expected tokenBodyField',
+            _tokenQueryParameterName: 'expected tokenQueryParameterName',
+            _authScheme: 'expected authScheme',
+            _passReqToCallback: false,
+            _verifOpts : {
+              algorithms: ['expected algorithms'],
+              issuer: 'expected issuer',
+              audience: 'expected audience',
+              ignoreExpiration: false
+            }
+          });
+          done();
+        });
+    });
+
+  });
+
 });

--- a/test/strategy-requests-test.js
+++ b/test/strategy-requests-test.js
@@ -194,6 +194,46 @@ describe('Strategy', function() {
 
     });
 
+    describe('handling request with dynamic options cannot be resolved', function() {
+
+        var info, optionsCallback;
+
+        before(function() {
+            var strategy = new Strategy(function(callback) {
+                optionsCallback = callback;
+            }, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+
+            mockVerifier.reset();
+
+            chai.passport.use(strategy)
+              .fail(function(i) {
+                  info = i;
+              })
+              .req(function(req) {
+                  req.body = {}
+              })
+              .authenticate();
+        });
+
+
+        it('should fail authentication when resolved as an error', function() {
+            optionsCallback(new Error('expected error message'));
+            expect(info).to.be.an.object;
+            expect(info.message).to.equal('expected error message');
+        });
+
+
+        it('should fail authentication when resolved with undefined options', function() {
+            optionsCallback(null, null);
+            expect(info).to.be.an.object;
+            expect(info.message).to.equal('No jwt options');
+        });
+
+    });
+
     describe('handling request url set to url.Url instead of string', function() {
 
         var info;


### PR DESCRIPTION
Hello,

This pull request provide a new way to give options to the JWT strategy.
You still able to give static `options` as previously, but `options` can now be a function that will be evaluated each time that `authenticate` is called.

As #38, it helps for multi-tenanted applications.
IMO both pull-requests can be merged, some people would like to make `secretOrKey` only dynamic, some other like us want the whole `options` to be dynamic.

Resolves issue #37
