### PR TITLE
allow secretOrKey to be a function PLUS pass request object to function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# IntelliJ Project
+.idea

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications, you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or null / undefied if a secret could not be determined.)
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or `null` / `undefined` if a secret could not be determined.
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or `null` / `undefined` if a secret could not be determined.
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback is of the form `done(err, secret)` where `err` will be `null` if there is no error.
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ A [Passport](http://passportjs.org/) strategy for authenticating with a
 This module lets you authenticate endpoints using a JSON Web token. It is
 intended to be used to secure RESTful endpoints without sessions.
 
+## Why this fork?
+This repo is a fork of a fork of the [original passport-jwt repository](https://github.com/themikenicholson/passport-jwt)
+
+The [original fork by davesag](https://github.com/davesag/passport-jwt/tree/feature/37_support_multi_tenanted_apps) added the ability
+to make the `secretOrKey` option be a function.
+
+My fork extends davesag's by giving the `secretOrKey` function the original request as a parameter.
+
+The `secretOrKey` function you specify should now look like this:
+
+```
+var jwtOptions = {
+	secretOrKey: function (token, req, callback) { ... }
+};
+```
+
+I added this because I have a project where the JWT secret for a particular request is populated in the request itself.
+
 ## Install
 
     npm install passport-jwt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token` and a callback. The callback is of the form `done(err, secret)` where `err` will be `null` if there is no error.
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications) you may provide a function take takes the `token`, incoming request, and a callback. The callback is of the form `done(err, secret)` where `err` will be `null` if there is no error.
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The jwt authentication strategy is constructed as follows:
 `options` is an object literal containing options to control how the token is
 extracted from the request or verified.
 
-* `secretOrKey` is a REQUIRED string or buffer containing the secret
+* `secretOrKey` is a REQUIRED string or buffer containing the secret, or function that calls back with a string or buffer
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature.
+  signature. In situations where the `secretOrKey` is dependent on the `issuer` (in the case of multi-tenanted applications, you may provide a function take takes the `token` and a callback. The callback's only param will be the secret, or null / undefied if a secret could not be determined.)
 * `issuer`: If defined the token issuer (iss) will be verified against this
   value.
 * `audience`: If defined, the token audience (aud) will be verified against

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -115,7 +115,7 @@ JwtStrategy.prototype.authenticate = function(req, options) {
     }
 
     // Verify the JWT
-    JwtStrategy.JwtVerifier(token, this._secretOrKey, this._verifOpts, function(jwt_err, payload) {
+    JwtStrategy.JwtVerifier(token, this._secretOrKey, this._verifOpts, req, function(jwt_err, payload) {
         if (jwt_err) {
             return self.fail(jwt_err);
         } else {

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,8 +1,8 @@
 var jwt = require('jsonwebtoken');
 
-module.exports  = function(token, secretOrKey, options, callback) {
+module.exports  = function(token, secretOrKey, options, req, callback) {
   if (typeof secretOrKey === 'function') {
-      secretOrKey(token, function(err, secret) {
+      secretOrKey(token, req, function(err, secret) {
         if (err) {
           callback(err, null);
         } else if (!secret) {

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,5 +1,15 @@
 var jwt = require('jsonwebtoken');
 
-module.exports  = function(token, secretOrKey, options, callback) { 
-    return jwt.verify(token, secretOrKey, options, callback);
+module.exports  = function(token, secretOrKey, options, callback) {
+  if (typeof secretOrKey === 'function') {
+      secretOrKey(token, function(secret) {
+        if (!secret) {
+          callback(new Error('Could not determine secret'), null);
+        } else {
+          return jwt.verify(token, secret, options, callback);
+        }
+      })
+  } else {
+      return jwt.verify(token, secretOrKey, options, callback);
+  }
 };

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -2,8 +2,10 @@ var jwt = require('jsonwebtoken');
 
 module.exports  = function(token, secretOrKey, options, callback) {
   if (typeof secretOrKey === 'function') {
-      secretOrKey(token, function(secret) {
-        if (!secret) {
+      secretOrKey(token, function(err, secret) {
+        if (err) {
+          callback(err, null);
+        } else if (!secret) {
           callback(new Error('Could not determine secret'), null);
         } else {
           return jwt.verify(token, secret, options, callback);

--- a/test/strategy-requests-test.js
+++ b/test/strategy-requests-test.js
@@ -13,7 +13,7 @@ describe('Strategy', function() {
         // Replace the JWT Verfier with a stub to capture the value
         // extracted from the request
         mockVerifier = sinon.stub();
-        mockVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
+        mockVerifier.callsArgWith(4, null, test_data.valid_jwt.payload);
         Strategy.JwtVerifier = mockVerifier;
     });
     

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -20,7 +20,7 @@ describe('Strategy', function() {
             strategy = new Strategy(options, verifyStub);
 
             Strategy.JwtVerifier = sinon.stub();
-            Strategy.JwtVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
+            Strategy.JwtVerifier.callsArgWith(4, null, test_data.valid_jwt.payload);
 
             chai.passport.use(strategy)
                 .success(function(u, i) {
@@ -73,7 +73,7 @@ describe('Strategy', function() {
 
             // Mock successful verification
             Strategy.JwtVerifier = sinon.stub();
-            Strategy.JwtVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
+            Strategy.JwtVerifier.callsArgWith(4, null, test_data.valid_jwt.payload);
 
             chai.passport.use(strategy)
                 .success(function(u, i) {
@@ -104,7 +104,7 @@ describe('Strategy', function() {
 
             // Mock errored verification
             Strategy.JwtVerifier = sinon.stub();
-            Strategy.JwtVerifier.callsArgWith(3, new Error("jwt expired"), false);
+            Strategy.JwtVerifier.callsArgWith(4, new Error("jwt expired"), false);
 
             chai.passport.use(strategy)
                 .fail(function(i) {

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -167,4 +167,72 @@ describe('Strategy', function() {
 
     });
 
+    describe('Handling a request with a valid JWT, secretOrKey is a function, and succesful verification', function() {
+        describe('secretOrKey function returns a secret', function() {
+            var strategy, user, info; 
+            var secretFunction = function(token, done) {
+                done('secret');
+            };
+
+            before(function(done) {
+                strategy = new Strategy({secretOrKey: secretFunction}, function(jwt_paylod, next) {
+                    return next(null, {user_id: 1234567890}, {foo:'bar'});
+                });
+
+                chai.passport.use(strategy)
+                    .success(function(u, i) {
+                        user = u;
+                        info = i;
+                        done();
+                    })
+                    .req(function(req) {
+                        req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    })
+                    .authenticate();
+            });
+
+
+            it('should provide a user', function() {
+                expect(user).to.be.an.object;
+                expect(user.user_id).to.equal(1234567890);
+            });
+
+
+            it('should forward info', function() {
+                expect(info).to.be.an.object;
+                expect(info.foo).to.equal('bar');
+            });
+        });
+
+        describe('secretOrKey function doesn\'t return a secret', function() {
+            var strategy, err; 
+            var secretFunction = function(token, done) {
+                done();
+            };
+
+            before(function(done) {
+                strategy = new Strategy({secretOrKey: secretFunction}, function(jwt_paylod, next) {
+                    return next(new Error('ERROR'), false, {message: 'Could not determine secret'});
+                });
+
+                chai.passport.use(strategy)
+                    .error(function(e) {
+                        err = e;
+                        done();
+                    })
+                    .req(function(req) {
+                        req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                    })
+                    .authenticate();
+            });
+
+
+            it('should error', function() {
+                expect(err).to.be.an.instanceof(Error);
+                expect(err.message).to.equal('ERROR');
+            });
+        });
+
+    });
+
 });

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -171,7 +171,7 @@ describe('Strategy', function() {
         describe('secretOrKey function returns a secret', function() {
             var strategy, user, info; 
             var secretFunction = function(token, done) {
-                done('secret');
+                done(null, 'secret');
             };
 
             before(function(done) {
@@ -207,7 +207,7 @@ describe('Strategy', function() {
         describe('secretOrKey function doesn\'t return a secret', function() {
             var strategy, err; 
             var secretFunction = function(token, done) {
-                done();
+                done(new Error('oops'), null);
             };
 
             before(function(done) {

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -170,7 +170,7 @@ describe('Strategy', function() {
     describe('Handling a request with a valid JWT, secretOrKey is a function, and succesful verification', function() {
         describe('secretOrKey function returns a secret', function() {
             var strategy, user, info; 
-            var secretFunction = function(token, done) {
+            var secretFunction = function(token, req, done) {
                 done(null, 'secret');
             };
 
@@ -206,7 +206,7 @@ describe('Strategy', function() {
 
         describe('secretOrKey function doesn\'t return a secret', function() {
             var strategy, err; 
-            var secretFunction = function(token, done) {
+            var secretFunction = function(token, req, done) {
                 done(new Error('oops'), null);
             };
 

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -8,7 +8,7 @@ describe('Strategy', function() {
 
     before(function() {
         Strategy.JwtVerifier = sinon.stub(); 
-        Strategy.JwtVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
+        Strategy.JwtVerifier.callsArgWith(4, null, test_data.valid_jwt.payload);
     });
 
     describe('Handling a request with a valid JWT and succesful verification', function() {


### PR DESCRIPTION
This is my fork off of [davesag's fork](https://github.com/davesag/passport-jwt/tree/feature/37_support_multi_tenanted_apps) (PR #37 ) that also gives the `secretOrKey` function the original request object. 

This is useful if you need information from the original request to determine which JWT secret to use
