### PR TITLE
Switch to using hasOwnProperty from the object prototype (nodejs v6)

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -40,7 +40,7 @@ extractors.fromUrlQueryParameter = function (param_name) {
     return function (request) {
         var token = null,
             parsed_url = url.parse(request.url, true);
-        if (parsed_url.query && parsed_url.query.hasOwnProperty(param_name)) {
+        if (parsed_url.query && Object.prototype.hasOwnProperty.call(parsed_url.query, param_name)) {
             token = parsed_url.query[param_name];
         }
         return token;


### PR DESCRIPTION
Since the response from url.parse no longer inherits from it: https://github.com/nodejs/node/pull/6289