### PR TITLE
gracefull json response when no token

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -84,7 +84,7 @@ JwtStrategy.prototype.authenticate = function(req, options) {
     var token = self._jwtFromRequest(req);
 
     if (!token) {
-        return self.fail(new Error("No auth token"));
+        return self.fail({ message: options.badRequestMessage || 'Missing token' }, 400);
     }
 
     // Verify the JWT


### PR DESCRIPTION
passport-jwt often used side-by-side with passport-local but it has a different approach for handling empty parameters. With this changes you can handle empty token error using next code:
`router.get('/protectedRoute', function (req, res, next) {`
`  passport.authenticate('jwt', { session: false }, function (err, user, info) {`
`    if (err) {`
`      return next(err);`
`    }`
`    if (!user) {`
`      return res.status(401).json(info);`
`    }`
`    // do your stuff here - just return 'user' for example `
`    return res.status(200).json(user);`
`  })(req, res, next);`
`});`