### PR TITLE
Fix body field extractor

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -27,7 +27,7 @@ extractors.fromHeader = function (header_name) {
 extractors.fromBodyField = function (field_name) {
     return function (request) {
         var token = null;
-        if (request.body && request.body.hasOwnProperty(field_name)) {
+        if (request.body && Object.prototype.hasOwnProperty.call(request.body, field_name)) {
             token = request.body[field_name];
         }
         return token;


### PR DESCRIPTION
When [querystring](https://nodejs.org/api/querystring.html) is used to parse the request body, `req.body` [does not inherit](https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options) from `Object.prototype`.

This patch fixes the call to `hasOwnProperty` in the same as we already did it for the URL query extractor (see #59).
