### PR TITLE
Get token both with custom header and custom scheme

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -23,6 +23,20 @@ extractors.fromHeader = function (header_name) {
 };
 
 
+extractors.fromHeaderWithScheme = function (header_name, auth_scheme) {
+    return function (request) {
+        var token = null;
+        if (request.headers[header_name]) {
+            var auth_params = auth_hdr.parse(request.headers[header_name]);
+            if (auth_params && auth_scheme === auth_params.scheme) {
+                token = auth_params.value;
+            }
+        }
+        return token;
+    };
+};
+
+
 
 extractors.fromBodyField = function (field_name) {
     return function (request) {


### PR DESCRIPTION
Making it possible to get jwt token both with using custom header and custom scheme.

e.g.

```js
http = require('passport-http'),
jwt = require('passport-jwt');

const opts = {};
opts.secretOrKey = 'secret';
opts.jwtFromRequest = jwt.ExtractJwt.fromHeaderWithScheme('x-authorization', 'x-JWT');
passport.use(new jwt.Strategy(opts, function(...) {...}));
```

then can request like below.

```sh
% curl -X "GET" "http://example.com/users" \
       -H "x-Authorization: x-JWT <your JWT token>"
```