### PR TITLE
Fix verifyFunction's Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ opts.jwtFromRequest = ExtractJwt.fromAuthHeader();
 opts.secretOrKey = 'secret';
 opts.issuer = "accounts.examplesoft.com";
 opts.audience = "yoursite.net";
-passport.use(new JwtStrategy(opts, function(jwt_payload, done) {
+passport.use(new JwtStrategy(opts, function(req, jwt_payload, done) {
     User.findOne({id: jwt_payload.sub}, function(err, user) {
         if (err) {
             return done(err, false);


### PR DESCRIPTION
The verifyFunction provides 3 parameters, not two. The first beeing the request, the second the payload and the third the usual callback.