### PR TITLE
Updated fromHeader to set the name to lowercase.

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -3,8 +3,6 @@
 var url = require('url'),
     auth_hdr = require('./auth_header');
 
-// Note: express http converts all headers
-// to lower case.
 var AUTH_HEADER = "authorization",
     DEFAULT_AUTH_SCHEME = "JWT";
 
@@ -15,8 +13,9 @@ var extractors = {};
 extractors.fromHeader = function (header_name) {
     return function (request) {
         var token = null;
-        if (request.headers[header_name.toLowerCase()]) {
-            token = request.headers[header_name.toLowerCase()];
+        var header = request.headers[header_name.toLowerCase()]
+        if (header) {
+            token = header;
         }
         return token;
     };

--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -15,8 +15,8 @@ var extractors = {};
 extractors.fromHeader = function (header_name) {
     return function (request) {
         var token = null;
-        if (request.headers[header_name]) {
-            token = request.headers[header_name];
+        if (request.headers[header_name.toLowerCase()]) {
+            token = request.headers[header_name.toLowerCase()];
         }
         return token;
     };


### PR DESCRIPTION
```
opts.jwtFromRequest = ExtractJwt.fromHeader('Bearer');
```
The above should work when header is set as 'Bearer', but passport-jwt returns a 401. Required to use `ExtractJwt.fromHeader('bearer');` for it to work. This should be case insensitive as headers are.

It's common practice for headers to start with a capital letter. I had that code above wondering why it wouldn't work, this fixed it, could be documented instead but I also saw people on stack overflow wondering why Bearer wouldn't work with fromHeader.