### PR TITLE
Add secret/key provider function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ The JWT authentication strategy is constructed as follows:
 `options` is an object literal containing options to control how the token is
 extracted from the request or verified.
 
-* `secretOrKey` is a REQUIRED string or buffer containing the secret
+* `secretOrKey` is a string or buffer containing the secret
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
-  signature.
-
+  signature. REQUIRED unless `secretOrKeyProvider` is provided.
+* `secretOrKeyProvider` is a callback in the format `function secretOrKeyProvider(req, token, done)`,
+  which should call `done` with a secret or PEM-encoded public key (asymmetric) for the given key and request combination.
+  `done` accepts arguments in the format `function done(err, secret)`.
+  REQUIRED unless `secretOrKey` is provided.
 * `jwtFromRequest` (REQUIRED) Function that accepts a request as the only
-  parameter and returns either the JWT as a string or *null*. See 
+  parameter and returns either the JWT as a string or *null*. See
   [Extracting the JWT from the request](#extracting-the-jwt-from-the-request) for
   more details.
 * `issuer`: If defined the token issuer (iss) will be verified against this
@@ -81,7 +84,7 @@ possible the JWT is parsed from the request by a user-supplied callback passed i
 `jwtFromRequest` parameter.  This callback, from now on referred to as an extractor,
 accepts a request object as an argument and returns the encoded JWT string or *null*.
 
-#### Included extractors 
+#### Included extractors
 
 A number of extractor factory functions are provided in passport-jwt.ExtractJwt. These factory
 functions return a new extractor configured with the given parameters.
@@ -102,7 +105,7 @@ functions return a new extractor configured with the given parameters.
 ### Writing a custom extractor function
 
 If the supplied extractors don't meet your needs you can easily provide your own callback. For
-example, if you are using the cookie-parser middleware and want to extract the JWT in a cookie 
+example, if you are using the cookie-parser middleware and want to extract the JWT in a cookie
 you could use the following function as the argument to the jwtFromRequest option:
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ extracted from the request or verified.
 * `secretOrKey` is a string or buffer containing the secret
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
   signature. REQUIRED unless `secretOrKeyProvider` is provided.
-* `secretOrKeyProvider` is a callback in the format `function secretOrKeyProvider(req, token, done)`,
+* `secretOrKeyProvider` is a callback in the format `function secretOrKeyProvider(token, done)`,
   which should call `done` with a secret or PEM-encoded public key (asymmetric) for the given key and request combination.
   `done` accepts arguments in the format `function done(err, secret)`.
   REQUIRED unless `secretOrKey` is provided.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -30,7 +30,9 @@ function JwtStrategy(options, verify) {
         if (this._secretOrKeyProvider) {
           	throw new TypeError('JwtStrategy has been given both a secretOrKey and a secretOrKeyProvider');
         }
-        this._secretOrKeyProvider = (token, done) => done(options.secretOrKey);
+        this._secretOrKeyProvider = function (token, done) {
+            done(options.secretOrKey)
+        };
     }
 
     if (!this._secretOrKeyProvider) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,10 +27,10 @@ function JwtStrategy(options, verify) {
     this._secretOrKeyProvider = options.secretOrKeyProvider;
 
     if (options.secretOrKey) {
-      if (this._secretOrKeyProvider) {
-        throw new TypeError('JwtStrategy has been given both a secretOrKey and a secretOrKeyProvider');
-      }
-      this._secretOrKeyProvider = (req, token, done) => done(options.secretOrKey);
+        if (this._secretOrKeyProvider) {
+          	throw new TypeError('JwtStrategy has been given both a secretOrKey and a secretOrKeyProvider');
+        }
+        this._secretOrKeyProvider = (token, done) => done(options.secretOrKey);
     }
 
     if (!this._secretOrKeyProvider) {
@@ -96,10 +96,7 @@ JwtStrategy.prototype.authenticate = function(req, options) {
     }
 
     // Verify the JWT
-    JwtStrategy.JwtVerifier(token,
-      this._secretOrKeyProvider.bind(null, req),
-      this._verifOpts,
-      function(jwt_err, payload) {
+    JwtStrategy.JwtVerifier(token, this._secretOrKeyProvider, this._verifOpts, function(jwt_err, payload) {
         if (jwt_err) {
             return self.fail(jwt_err);
         } else {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -30,7 +30,7 @@ function JwtStrategy(options, verify) {
       if (this._secretOrKeyProvider) {
         throw new TypeError('JwtStrategy has been given both a secretOrKey and a secretOrKeyProvider');
       }
-      this._secretOrKeyProvider = () => Promise.resolve(options.secretOrKey);
+      this._secretOrKeyProvider = (req, token, done) => done(options.secretOrKey);
     }
 
     if (!this._secretOrKeyProvider) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -24,8 +24,16 @@ function JwtStrategy(options, verify) {
     passport.Strategy.call(this);
     this.name = 'jwt';
 
-    this._secretOrKey = options.secretOrKey;
-    if (!this._secretOrKey) {
+    this._secretOrKeyProvider = options.secretOrKeyProvider;
+
+    if (options.secretOrKey) {
+      if (this._secretOrKeyProvider) {
+        throw new TypeError('JwtStrategy has been given both a secretOrKey and a secretOrKeyProvider');
+      }
+      this._secretOrKeyProvider = () => Promise.resolve(options.secretOrKey);
+    }
+
+    if (!this._secretOrKeyProvider) {
         throw new TypeError('JwtStrategy requires a secret or key');
     }
 
@@ -88,7 +96,10 @@ JwtStrategy.prototype.authenticate = function(req, options) {
     }
 
     // Verify the JWT
-    JwtStrategy.JwtVerifier(token, this._secretOrKey, this._verifOpts, function(jwt_err, payload) {
+    JwtStrategy.JwtVerifier(token,
+      this._secretOrKeyProvider.bind(null, req),
+      this._verifOpts,
+      function(jwt_err, payload) {
         if (jwt_err) {
             return self.fail(jwt_err);
         } else {

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,5 +1,7 @@
 var jwt = require('jsonwebtoken');
 
-module.exports  = function(token, secretOrKey, options, callback) { 
-    return jwt.verify(token, secretOrKey, options, callback);
+module.exports  = function(token, secretOrKeyProvider, options, callback, verify = jwt.verify) {
+  return secretOrKeyProvider(token)
+    .then(secretOrKey => verify(token, secretOrKey, options, callback))
+    .catch(error => callback(error));
 };

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,7 +1,11 @@
 var jwt = require('jsonwebtoken');
 
 module.exports  = function(token, secretOrKeyProvider, options, callback, verify = jwt.verify) {
-  return secretOrKeyProvider(token)
-    .then(secretOrKey => verify(token, secretOrKey, options, callback))
-    .catch(error => callback(error));
+  return secretOrKeyProvider(token, (err, secretOrKey) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    verify(token, secretOrKey, options, callback);
+  });
 };

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,11 +1,11 @@
 var jwt = require('jsonwebtoken');
 
 module.exports  = function(token, secretOrKeyProvider, options, callback, verify = jwt.verify) {
-  return secretOrKeyProvider(token, (err, secretOrKey) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-    verify(token, secretOrKey, options, callback);
-  });
+    return secretOrKeyProvider(token, (err, secretOrKey) => {
+        if (err) {
+            callback(err);
+            return;
+        }
+        verify(token, secretOrKey, options, callback);
+    });
 };

--- a/lib/verify_jwt.js
+++ b/lib/verify_jwt.js
@@ -1,7 +1,10 @@
 var jwt = require('jsonwebtoken');
 
-module.exports  = function(token, secretOrKeyProvider, options, callback, verify = jwt.verify) {
-    return secretOrKeyProvider(token, (err, secretOrKey) => {
+module.exports  = function(token, secretOrKeyProvider, options, callback, verify) {
+    if (!verify) {
+      verify = jwt.verify;
+    }
+    return secretOrKeyProvider(token, function (err, secretOrKey) {
         if (err) {
             callback(err);
             return;

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -35,8 +35,10 @@ describe('Strategy', function() {
         });
 
 
-        it('should call with the right secret as an argument', function() {
-            expect(Strategy.JwtVerifier.args[0][1]).to.equal('secret');
+        it('should call with the a function that resolves to secret', function() {
+          const secretOrKeyProvider = Strategy.JwtVerifier.args[0][1];
+          expect(secretOrKeyProvider).to.be.a('function');
+          return secretOrKeyProvider().then(secret => expect(secret).to.equal('secret'));
         });
 
 

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -9,52 +9,40 @@ describe('Strategy', function() {
     describe('calling JWT validation function', function() {
         var strategy;
 
-        function createStrategy() {
-            const verifyStub = sinon.stub();
+        before(function(done) {
+            verifyStub = sinon.stub();
             verifyStub.callsArgWith(1, null, {}, {});
-            const options = {};
+            options = {};
             options.issuer = "TestIssuer";
             options.audience = "TestAudience";
             options.secretOrKey = 'secret';
             options.algorithms = ["HS256", "HS384"];
             options.ignoreExpiration = false;
             options.jwtFromRequest = extract_jwt.fromAuthHeader();
-            const strategy = new Strategy(options, verifyStub);
+            strategy = new Strategy(options, verifyStub);
 
             Strategy.JwtVerifier = sinon.stub();
             Strategy.JwtVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
-            return strategy;
-        }
 
-        function testStrategy(strategy, done) {
-          chai.passport.use(strategy)
-              .success(function(u, i) {
-                  done();
-              })
-              .req(function(req) {
-                  req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
-              })
-              .authenticate();
-        }
-
-
-        it('should be given a function that calls done with the secretOrKey when passed the token', function(done) {
-          const strategy = createStrategy();
-          const secretOrKeyProvider = Strategy.JwtVerifier.args[0][1];
-          const doneSpy = sinon.spy();
-          secretOrKeyProvider(null, doneSpy);
-          expect(doneSpy.calledWith('secret')).to.be.true;
-          testStrategy(done);
+            chai.passport.use(strategy)
+                .success(function(u, i) {
+                    done();
+                })
+                .req(function(req) {
+                    req.headers['authorization'] = "JWT " + test_data.valid_jwt.token;
+                })
+                .authenticate();
         });
 
-        it('should pass secretOrKeyProvider to the verifier if provided', (done) => {
-          const strategy = createStrategy();
-          const secretOrKeyProvider = sinon.spy();
-          testStrategy(done);
+
+        it('should be given a function that calls done with the secretOrKey when passed the token', function() {
+            const secretOrKeyProvider = Strategy.JwtVerifier.args[0][1];
+            const doneSpy = sinon.spy();
+            secretOrKeyProvider(null, doneSpy);
+            expect(doneSpy.calledWith('secret')).to.be.true;
         });
 
         it('should call with the right issuer option', function() {
-            const strategy = createStrategy();
             expect(Strategy.JwtVerifier.args[0][2]).to.be.an.object;
             expect(Strategy.JwtVerifier.args[0][2].issuer).to.equal('TestIssuer');
         });

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -170,9 +170,11 @@ describe('Strategy', function() {
 
     });
 
-    describe('verify function', () => {
-        it('should call the secretOrKeyProvider with the token and pass it to verify', () => {
-            const provider = sinon.spy((token, done) => done(null, 'secret'));
+    describe('verify function', function() {
+        it('should call the secretOrKeyProvider with the token and pass it to verify', function() {
+            const provider = sinon.spy(function(token, done) {
+              done(null, 'secret');
+            });
             const verifyStub = sinon.stub();
             verify(test_data.valid_jwt.payload, provider, null, null, verifyStub);
             expect(provider.calledOnce).to.be.true;
@@ -180,8 +182,10 @@ describe('Strategy', function() {
             expect(verifyStub.calledWith(test_data.valid_jwt.payload, 'secret')).to.be.true;
         });
 
-        it('should call the callback with an error if the secretOrKeyProvider fails to return a key', () => {
-            const providerStub = (token, done) => done(new Error('invalid key'));
+        it('should call the callback with an error if the secretOrKeyProvider fails to return a key', function() {
+            const providerStub = function(token, done) {
+              done(new Error('invalid key'));
+            };
             const callback = sinon.spy();
             verify(test_data.valid_jwt.payload, providerStub, null, callback);
             expect(callback.calledWith(sinon.match.instanceOf(Error)));

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -171,21 +171,21 @@ describe('Strategy', function() {
     });
 
     describe('verify function', () => {
-      it('should call the secretOrKeyProvider with the token and pass it to verify', () => {
-        const provider = sinon.spy((token, done) => done(null, 'secret'));
-        const verifyStub = sinon.stub();
-        verify(test_data.valid_jwt.payload, provider, null, null, verifyStub);
-        expect(provider.calledOnce).to.be.true;
-        expect(provider.calledWith(test_data.valid_jwt.payload)).to.be.true;
-        expect(verifyStub.calledWith(test_data.valid_jwt.payload, 'secret')).to.be.true;
-      });
+        it('should call the secretOrKeyProvider with the token and pass it to verify', () => {
+            const provider = sinon.spy((token, done) => done(null, 'secret'));
+            const verifyStub = sinon.stub();
+            verify(test_data.valid_jwt.payload, provider, null, null, verifyStub);
+            expect(provider.calledOnce).to.be.true;
+            expect(provider.calledWith(test_data.valid_jwt.payload)).to.be.true;
+            expect(verifyStub.calledWith(test_data.valid_jwt.payload, 'secret')).to.be.true;
+        });
 
-      it('should call the callback with an error if the secretOrKeyProvider fails to return a key', () => {
-        const providerStub = (token, done) => done(new Error('invalid key'));
-        const callback = sinon.spy();
-        verify(test_data.valid_jwt.payload, providerStub, null, callback);
-        expect(callback.calledWith(sinon.match.instanceOf(Error)));
-      });
+        it('should call the callback with an error if the secretOrKeyProvider fails to return a key', () => {
+            const providerStub = (token, done) => done(new Error('invalid key'));
+            const callback = sinon.spy();
+            verify(test_data.valid_jwt.payload, providerStub, null, callback);
+            expect(callback.calledWith(sinon.match.instanceOf(Error)));
+        });
     });
 
 });

--- a/test/strategy-verify-test.js
+++ b/test/strategy-verify-test.js
@@ -171,22 +171,20 @@ describe('Strategy', function() {
     });
 
     describe('verify function', () => {
-      it('should call the secretOrKeyProvider with the token', () => {
-        var provider = sinon.stub().returns(Promise.resolve('secret'));
-        var verifyStub = sinon.spy();
-        return verify(test_data.valid_jwt.payload, provider, null, null, verifyStub).then(() => {
-          expect(provider.calledWith(test_data.valid_jwt.payload)).to.be.true;
-          expect(verifyStub.calledWith(test_data.valid_jwt.payload, 'secret'));
-        });
+      it('should call the secretOrKeyProvider with the token and pass it to verify', () => {
+        const provider = sinon.spy((token, done) => done(null, 'secret'));
+        const verifyStub = sinon.stub();
+        verify(test_data.valid_jwt.payload, provider, null, null, verifyStub);
+        expect(provider.calledOnce).to.be.true;
+        expect(provider.calledWith(test_data.valid_jwt.payload)).to.be.true;
+        expect(verifyStub.calledWith(test_data.valid_jwt.payload, 'secret')).to.be.true;
       });
 
       it('should call the callback with an error if the secretOrKeyProvider fails to return a key', () => {
-        var provider = sinon.stub().returns(Promise.reject(new Error('No key')));
-        var callback = sinon.spy();
-        return verify(test_data.valid_jwt.payload, provider, null, callback).then(() => {
-          expect(callback.calledWith(sinon.match.instanceOf(Error)));
-        });
-
+        const providerStub = (token, done) => done(new Error('invalid key'));
+        const callback = sinon.spy();
+        verify(test_data.valid_jwt.payload, providerStub, null, callback);
+        expect(callback.calledWith(sinon.match.instanceOf(Error)));
       });
     });
 


### PR DESCRIPTION
Adds a function called `secretOrKeyProvider` as discussed in #94. The existing `secretOrKey` option is supported by creating a provider that just returns that secret or key immediately.

Apologies for the random whitespace removals, Atom does it automatically when I save files.