### PR TITLE
Enhancement to options:

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ extracted from the request or verified.
 * `ignoreExpiration`: if true do not validate the expiration of the token.
 * `passReqToCallback`: If true the request will be passed to the verify
   callback. i.e. verify(request, jwt_payload, done_callback).
+* `jsonWebTokenOptions`: passport-jwt is verifying the token using [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
+Pass here an options object for any other option you can pass the jsonwebtoken verifier. (i.e maxAge)
 
 `verify` is a function with the parameters `verify(jwt_payload, done)`
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -40,23 +40,16 @@ function JwtStrategy(options, verify) {
     }
 
     this._passReqToCallback = options.passReqToCallback;
-    this._verifOpts = {};
-
-    if (options.issuer) {
-        this._verifOpts.issuer = options.issuer;
-    }
-
-    if (options.audience) {
-        this._verifOpts.audience = options.audience;
-    }
-
-    if (options.algorithms) {
-        this._verifOpts.algorithms = options.algorithms;
-    }
-
-    if (options.ignoreExpiration !== undefined) {
-        this._verifOpts.ignoreExpiration = options.ignoreExpiration;
-    }
+    let jsonWebTokenOptions = options.jsonWebTokenOptions || {};
+    //for backwards compatibility, still allowing you to pass
+    //audience / issuer / algorithms / ignoreException
+    //on the options.
+    this._verifOpts = Object.assign({}, jsonWebTokenOptions, {
+      audience: options.audience,
+      issuer: options.issuer,
+      algorithms: options.algorithms,
+      ignoreExpiration: !!options.ignoreExpiration
+    });
 
 }
 util.inherits(JwtStrategy, passport.Strategy);

--- a/test/strategy-validation-test.js
+++ b/test/strategy-validation-test.js
@@ -18,6 +18,10 @@ describe('Strategy', function() {
             options.secretOrKey = 'secret';
             options.algorithms = ["HS256", "HS384"];
             options.ignoreExpiration = false;
+            options.jsonWebTokenOptions = {
+              clockTolerance: 10,
+              maxAge: "1h",
+            };
             options.jwtFromRequest = extract_jwt.fromAuthHeader();
             strategy = new Strategy(options, verifyStub);
 
@@ -59,6 +63,16 @@ describe('Strategy', function() {
         it('should call with the right ignoreExpiration option', function() {
             expect(Strategy.JwtVerifier.args[0][2]).to.be.an.object;
             expect(Strategy.JwtVerifier.args[0][2].ignoreExpiration).to.be.false;
+        });
+
+        it('should call with the right maxAge option', function() {
+            expect(Strategy.JwtVerifier.args[0][2]).to.be.an.object;
+            expect(Strategy.JwtVerifier.args[0][2].maxAge).to.equal('1h');
+        });
+
+        it('should call with the right clockTolerance option', function() {
+            expect(Strategy.JwtVerifier.args[0][2]).to.be.an.object;
+            expect(Strategy.JwtVerifier.args[0][2].clockTolerance).to.equal(10);
         });
 
     });


### PR DESCRIPTION
Added `jsonWebTokenOptions` to options, which allows one to pass
additional options to node-jsonwebtoken verifier. This way there
won't be a need to change passport-jwt for any other custom
option used in the verifier.