### PR TITLE
Removed confusing option parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ var cookieExtractor = function(req) {
 Use `passport.authenticate()` specifying `'JWT'` as the strategy.
 
 ```js
-app.post('/profile', passport.authenticate('jwt', { session: false }),
+app.post('/profile', passport.authenticate('jwt'),
     function(req, res) {
         res.send(req.user.profile);
     }


### PR DESCRIPTION
The `{session:false}` parameter was causing some [confusion](#96) and as we can see from the [`authenticate` function](https://github.com/themikenicholson/passport-jwt/blob/master/lib/strategy.js#L81) there is no need to pass even any options when authenticating.