### PR TITLE
Changed scheme comparison to be case insensitive

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -55,7 +55,7 @@ extractors.fromAuthHeaderWithScheme = function (auth_scheme) {
         var token = null;
         if (request.headers[AUTH_HEADER]) {
             var auth_params = auth_hdr.parse(request.headers[AUTH_HEADER]);
-            if (auth_params && auth_scheme === auth_params.scheme) {
+            if (auth_params && auth_scheme.toLowerCase() === auth_params.scheme.toLowerCase()) {
                 token = auth_params.value;
             }
         }


### PR DESCRIPTION
The authentication scheme type comparison should be case insensitive. It's detailed in the [OAuth 2.0 RFC](https://tools.ietf.org/html/rfc6749#section-5.1), see `token_type`.