### PR TITLE
update to jsonwebtoken v8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sinon": "^1.0.0"
   },
   "dependencies": {
-    "jsonwebtoken": "^7.0.0",
+    "jsonwebtoken": "^8.1.0",
     "passport-strategy": "^1.0.0"
   }
 }


### PR DESCRIPTION
The jsonwebtoken [migration guide](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v7-to-v8) does not note any breaking changes related to this library's usage. All tests pass.

Closes #131 